### PR TITLE
Move IMPROV announcement

### DIFF
--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -83,11 +83,6 @@ public:
             SPIFFS.remove(IMPROV_LOG_FILE);
         #endif
 
-        if (WiFi.getMode() == WIFI_STA && WiFi.isConnected())
-            this->state_ = improv::STATE_PROVISIONED;
-        else
-            this->state_ = improv::STATE_AUTHORIZED;
-        debugI("Sending Improv packet to declare we're up. Ignore any IMPROV lines that follow this one.");
         log_write("Finished Improv setup");
     }
 
@@ -97,6 +92,13 @@ public:
 
     void loop()
     {
+        static bool announcedPresence = [&]
+        {
+            debugI("Sending Improv packet to declare we're up. Ignore any IMPROV lines that follow this one.");
+            this->set_state_(improv::STATE_AUTHORIZED);
+            return true;
+        }();
+
         const uint32_t now = millis();
         if (now - this->last_read_byte_ > 50)
         {


### PR DESCRIPTION
As discussed in PlummersSoftwareLLC#596, this moves the announcement of our presence to the `loop()` function. This may address the issue of LEDs not lighting up in certain situations.